### PR TITLE
Load API settings from configuration

### DIFF
--- a/OneMinuteIntegrationOfAPI/Program.cs
+++ b/OneMinuteIntegrationOfAPI/Program.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using OneMinuteIntegrationOfAPI;
 using OneMinuteIntegrationOfAPI.Interfaces;
 using OneMinuteIntegrationOfAPI.Services;
+using Microsoft.Extensions.Configuration;
 
 var builder = WebAssemblyHostBuilder.CreateDefault(args);
 builder.RootComponents.Add<App>("#app");
@@ -10,8 +11,11 @@ builder.RootComponents.Add<HeadOutlet>("head::after");
 
 builder.Services.AddScoped(sp => new HttpClient
 {
-    BaseAddress = new Uri(builder.HostEnvironment.BaseAddress),
+    BaseAddress = new Uri(builder.Configuration["MxFace:ApiBaseUrl"] ?? builder.HostEnvironment.BaseAddress),
 });
+
+// Allow services to access configuration values
+builder.Services.AddSingleton<IConfiguration>(builder.Configuration);
 
 builder.Services.AddScoped<ICommonService, CommonService>();
 builder.Services.AddScoped<IServiceUsageHistoryService, ServiceUsageHistoryService>();

--- a/OneMinuteIntegrationOfAPI/Services/ServiceUsageHistoryService.cs
+++ b/OneMinuteIntegrationOfAPI/Services/ServiceUsageHistoryService.cs
@@ -1,5 +1,6 @@
 using OneMinuteIntegrationOfAPI.Interfaces;
 using OneMinuteIntegrationOfAPI.Models;
+using Microsoft.Extensions.Configuration;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 
@@ -8,8 +9,8 @@ public class ServiceUsageHistoryService : IServiceUsageHistoryService
     private readonly ICommonService _commonService;
     private readonly HttpClient _httpClient;
     private readonly IConfiguration _config;
-    private const string API_BASE_URL = "https://api.mxface.ai";
-    private const string ACCESS_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1bmlxdWVfbmFtZSI6Ijg5NyIsInJvbGUiOiJBZG1pbiIsImNsYWltUm9sZSI6IkFkbWluIiwiY2xhaW1DbGllbnRJZCI6Ijg5NyIsIm5iZiI6MTc1NzA3NzU1NiwiZXhwIjoxODIwMTQ5NTU2LCJpYXQiOjE3NTcwNzc1NTZ9.A7C_BOgz2OrlnB2kRmg7HW7iKJfh_YJnioTscz2y7G0";
+    private readonly string _apiBaseUrl;
+    private readonly string _accessKey;
 
     public ServiceUsageHistoryService(
         ICommonService commonService,
@@ -20,21 +21,24 @@ public class ServiceUsageHistoryService : IServiceUsageHistoryService
         _commonService = commonService;
         _httpClient = httpClient;
         _config = config;
+
+        _apiBaseUrl = _config["MxFace:ApiBaseUrl"] ?? string.Empty;
+        _accessKey = _config["MxFace:AccessKey"] ?? string.Empty;
     }
 
     public async Task<ClientPackageDto> GetClientUsage()
     {
         var clientId = _commonService.GetClientId(); // This returns 4437
 
-        Console.WriteLine($"AccessKey: {ACCESS_KEY}");
-        Console.WriteLine($"ApiBaseUrl: {API_BASE_URL}");
+        Console.WriteLine($"AccessKey: {_accessKey}");
+        Console.WriteLine($"ApiBaseUrl: {_apiBaseUrl}");
 
         _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
             "Bearer",
-            ACCESS_KEY
+            _accessKey
         );
         var response = await _httpClient.GetAsync(
-            $"{API_BASE_URL}/api/SubscriptionPlans/GetSubscriptionPackage?activeId=1&clientId={clientId}"
+            $"{_apiBaseUrl}/api/SubscriptionPlans/GetSubscriptionPackage?activeId=1&clientId={clientId}"
         );
 
         if (!response.IsSuccessStatusCode)
@@ -46,3 +50,4 @@ public class ServiceUsageHistoryService : IServiceUsageHistoryService
         return packages?.FirstOrDefault() ?? new ClientPackageDto();
     }
 }
+


### PR DESCRIPTION
## Summary
- Resolve `IConfiguration` in DI and apply API base URL when creating `HttpClient`.
- Read API base URL and access key from configuration in `ServiceUsageHistoryService` instead of hardcoded constants.

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68becc75165c832aa2db6db1ef876ad0